### PR TITLE
WIP: hand eye calib fix

### DIFF
--- a/hand_eye_calibration/python/hand_eye_calibration/time_alignment.py
+++ b/hand_eye_calibration/python/hand_eye_calibration/time_alignment.py
@@ -215,7 +215,7 @@ def interpolate_poses_from_samples(time_stamped_poses, samples):
 
   return aligned_poses.copy()
 
-def _filter_max_value(array, max_val):
+def _filter_smaller_than(array, max_val):
     return array[np.where(np.abs(array) < max_val)]
 
 def compute_aligned_poses(time_stamped_poses_A,
@@ -241,8 +241,8 @@ def compute_aligned_poses(time_stamped_poses_A,
 
   # Resample at the lower frequency to prevent introducing more noise.
   max_diff_s = 1.
-  dt_A = np.mean(_filter_max_value(np.diff(time_stamped_poses_A_shifted[:, 0]), max_diff_s))
-  dt_B = np.mean(_filter_max_value(np.diff(time_stamped_poses_B[:, 0]), max_diff_s))
+  dt_A = np.mean(_filter_smaller_than(np.diff(time_stamped_poses_A_shifted[:, 0]), max_diff_s))
+  dt_B = np.mean(_filter_smaller_than(np.diff(time_stamped_poses_B[:, 0]), max_diff_s))
   if dt_A >= dt_B:
     dt = dt_A
     timestamps_low = time_stamped_poses_A_shifted[:, 0].T

--- a/hand_eye_calibration/python/hand_eye_calibration/time_alignment.py
+++ b/hand_eye_calibration/python/hand_eye_calibration/time_alignment.py
@@ -215,6 +215,8 @@ def interpolate_poses_from_samples(time_stamped_poses, samples):
 
   return aligned_poses.copy()
 
+def _filter_max_value(array, max_val):
+    return array[np.where(np.abs(array) < max_val)]
 
 def compute_aligned_poses(time_stamped_poses_A,
                           time_stamped_poses_B,
@@ -238,16 +240,17 @@ def compute_aligned_poses(time_stamped_poses_A,
   interval = end_time - start_time
 
   # Resample at the lower frequency to prevent introducing more noise.
-  dt_A = np.mean(np.diff(time_stamped_poses_A_shifted[:, 0]))
-  dt_B = np.mean(np.diff(time_stamped_poses_B[:, 0]))
+  max_diff_s = 1.
+  dt_A = np.mean(_filter_max_value(np.diff(time_stamped_poses_A_shifted[:, 0]), max_diff_s))
+  dt_B = np.mean(_filter_max_value(np.diff(time_stamped_poses_B[:, 0]), max_diff_s))
   if dt_A >= dt_B:
-    dt = dt_B
-    timestamps_low = time_stamped_poses_B[:, 0].T
-    timestamps_high = time_stamped_poses_A_shifted[:, 0].T
-  else:
     dt = dt_A
     timestamps_low = time_stamped_poses_A_shifted[:, 0].T
     timestamps_high = time_stamped_poses_B[:, 0].T
+  else:
+    dt = dt_B
+    timestamps_low = time_stamped_poses_B[:, 0].T
+    timestamps_high = time_stamped_poses_A_shifted[:, 0].T
 
   # Create samples at time stamps from lower frequency signal, check if there
   # are timely close samples available from the other signal.

--- a/hand_eye_calibration/python/hand_eye_calibration/time_alignment.py
+++ b/hand_eye_calibration/python/hand_eye_calibration/time_alignment.py
@@ -241,13 +241,13 @@ def compute_aligned_poses(time_stamped_poses_A,
   dt_A = np.mean(np.diff(time_stamped_poses_A_shifted[:, 0]))
   dt_B = np.mean(np.diff(time_stamped_poses_B[:, 0]))
   if dt_A >= dt_B:
-    dt = dt_A
-    timestamps_low = time_stamped_poses_A_shifted[:, 0].T
-    timestamps_high = time_stamped_poses_B[:, 0].T
-  else:
     dt = dt_B
     timestamps_low = time_stamped_poses_B[:, 0].T
     timestamps_high = time_stamped_poses_A_shifted[:, 0].T
+  else:
+    dt = dt_A
+    timestamps_low = time_stamped_poses_A_shifted[:, 0].T
+    timestamps_high = time_stamped_poses_B[:, 0].T
 
   # Create samples at time stamps from lower frequency signal, check if there
   # are timely close samples available from the other signal.


### PR DESCRIPTION
Tries to fix an issue with `compute_aligned_poses` when one of the two input trajectories contains big gaps.

`compute_aligned_poses` automatically selects one of the two input trajectories as the one which sets the baseline frequency, which shall be the the one with the lower pose frequency. The current way of computing the pose frequency breaks down if a high frequency trajectory contains big gaps, which results in a low mean pose frequency.

This fix proposes to filter big gaps out of the mean-frequency computation. It's less clear if this is a good solution by introducing the filtering parameter or whether better approaches exist.